### PR TITLE
Add demo notebook and update README with usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,10 @@ destination_addresses = locations_df['Address'][2:].tolist()
 By default, the fetcher uses these [Google Maps Distance Matrix API settings](https://github.com/googlemaps/google-maps-services-python/blob/master/googlemaps/distance_matrix.py):  
 - `mode`: `"driving"`
 - `departure_time`: `"now"`  
-These defaults are suitable for real-time distance estimation using current road conditions.
+
+These defaults are suitable for real-time distance estimation using current road conditions.  
+
+Run the pipeline yourself: Follow the [demo notebook](notebooks/demo_default_pipeline.ipynb) for a guided step-by-step example.  
 
 ```python
 from distance_matrix.fetcher import GoogleMapsFetcher

--- a/notebooks/demo_default_pipeline.ipynb
+++ b/notebooks/demo_default_pipeline.ipynb
@@ -173,16 +173,9 @@
     "\n",
     "df = pd.read_csv(export_path)\n",
     "df.set_index(\"Matrix\", inplace=True)\n",
+    "\n",
     "print(df)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1b279997-24a4-4f9e-9f62-59b101501a2b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/demo_default_pipeline.ipynb
+++ b/notebooks/demo_default_pipeline.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9405edc2-efd9-4ce0-bfbc-3a42dc899078",
+   "metadata": {},
+   "source": [
+    "# 🧪 Demo: Default Pipeline\n",
+    "\n",
+    "This notebook demonstrates the default usage of the **Distance Matrix Generator**:\n",
+    "- Fetch travel data from the Google Maps API\n",
+    "- Generate a distance matrix\n",
+    "- Optionally store data in a SQL database\n",
+    "- Display the output as a pandas DataFrame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f2c4ce5-8226-4140-a4d9-2bce336ec215",
+   "metadata": {},
+   "source": [
+    "## 🛠️ Setup\n",
+    "\n",
+    "To run the pipeline in Jupyter Notebook, we add the project root to `sys.path`.\n",
+    "\n",
+    "We also import `pandas` for output preview and load the pipeline modules from the project.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "69c7a87c-8818-4dc6-bc28-c792e5e36f44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "sys.path.append(os.path.abspath(\"..\"))\n",
+    "\n",
+    "import pandas as pd\n",
+    "from distance_matrix.fetcher import GoogleMapsFetcher\n",
+    "from distance_matrix.generator import DistanceMatrixGenerator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10f8d777-f7da-4f2d-97f8-1242442cf563",
+   "metadata": {},
+   "source": [
+    "## 📍 Input Data\n",
+    "\n",
+    "Create or load origin and destination data.\n",
+    "\n",
+    "It's recommended to use dictionaries in the form `{label: location}` for better readability in the distance matrix and database output.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "065a6018-a2d4-451f-b1e2-5352f34053af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "origin_dictionary = {\n",
+    "    \"Port of Rotterdam\": \"Wilhelminakade 909, 3072 AP Rotterdam, Netherlands\",\n",
+    "    \"Port of Antwerp\": \"Loodglansstraat 5, 2030 Antwerpen, Belgium\"\n",
+    "}\n",
+    "\n",
+    "destination_dictionary = {\n",
+    "    \"Port of Hamburg\": \"Am Ballinkai 1, 21129 Hamburg, Germany\",\n",
+    "    \"Port of Bremerhaven\": \"27580 Bremerhaven, Germany\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f1c33ef-440e-4d8e-aaf4-f97e61ac5de6",
+   "metadata": {},
+   "source": [
+    "## 🌐 Fetch Travel Data\n",
+    "\n",
+    "Use the `GoogleMapsFetcher` to request real-world travel data between all origin–destination pairs.\n",
+    "\n",
+    "Results are stored as a JSON response with metadata.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "827f7e0d-68c4-4e7e-88d1-59f29b22cf14",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved API response to ../data/raw/gmaps_dist_matrix_data_Wilhel_Loodgl_AmBall_922d24f.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "fetcher = GoogleMapsFetcher(list(origin_dictionary.values()), list(destination_dictionary.values()))\n",
+    "fetcher.run_fetch_pipeline()\n",
+    "request_filename = fetcher.filename"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f6c1ca4-12e7-417f-b51f-7c0f4f66bb1b",
+   "metadata": {},
+   "source": [
+    "## 🏗️ Generate Distance Matrix\n",
+    "\n",
+    "Use the `DistanceMatrixGenerator` to transform the raw API response into a structured CSV matrix and optionally store the data in a SQL database.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a196e07e-9bfa-436d-b2be-8c52f88bc800",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DB CREATED READY TO CONTINUE\n",
+      "Data Frame has been written to ../data/processed/gmaps_dist_matrix_data_Wilhel_Loodgl_AmBall_922d24f.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "generator = DistanceMatrixGenerator(request_filename,\n",
+    "                                    list(origin_dictionary.keys()),\n",
+    "                                    list(destination_dictionary.keys()),\n",
+    "                                    write_to_db=True,\n",
+    "                                    dbms='mysql',\n",
+    "                                    db_name='test_distance_database')\n",
+    "generator.build_matrix()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e214ac9f-dbdc-4e16-9bbb-7cf523183aae",
+   "metadata": {},
+   "source": [
+    "## 📊 Preview Output\n",
+    "\n",
+    "Load and display the generated distance matrix from the `data/processed/` directory using pandas.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "78916991-e416-4952-9d2d-3addc57c990d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   Port Of Hamburg  Port Of Bremerhaven\n",
+      "Matrix                                                 \n",
+      "Port Of Rotterdam            491.0                416.0\n",
+      "Port Of Antwerp              548.0                475.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "directory = '../data/processed/'\n",
+    "export_path = os.path.join(directory, f\"{request_filename}.csv\")\n",
+    "\n",
+    "df = pd.read_csv(export_path)\n",
+    "df.set_index(\"Matrix\", inplace=True)\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b279997-24a4-4f9e-9f62-59b101501a2b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Added `notebooks/demo_default_pipeline.ipynb` to provide a step-by-step demonstration of the default pipeline, including data fetching, matrix generation, and output preview. Updated `README.md` to reference the new demo notebook for user guidance.